### PR TITLE
Fix undesired behaviour on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 *.swp
+.vs

--- a/wxVTKRenderWindowInteractor.h
+++ b/wxVTKRenderWindowInteractor.h
@@ -38,7 +38,6 @@ class wxVTKRenderWindowInteractor : public wxWindow, public vtkRenderWindowInter
   DECLARE_DYNAMIC_CLASS(wxVTKRenderWindowInteractor)
   public:
   wxVTKRenderWindowInteractor();
-
   wxVTKRenderWindowInteractor(
     wxWindow* parent,
     wxWindowID id,
@@ -68,8 +67,6 @@ class wxVTKRenderWindowInteractor : public wxWindow, public vtkRenderWindowInter
   void OnButtonDown(wxMouseEvent &event);
   void OnButtonUp(wxMouseEvent &event);
 
-  void OnEnter(wxMouseEvent &event);
-  void OnLeave(wxMouseEvent &event);
   void OnMouseWheel(wxMouseEvent& event);
   void OnKeyDown(wxKeyEvent &event);
   void OnKeyUp(wxKeyEvent &event);
@@ -95,33 +92,6 @@ class wxVTKRenderWindowInteractor : public wxWindow, public vtkRenderWindowInter
   virtual int InternalDestroyTimer(int platformTimerId);
 
   private:
-  inline void SetEventInformationCentralize(
-      int x, 
-      int y, 
-      int ctrl = 0, 
-      int shift = 0, 
-      char keycode = 0, 
-      int repeatcount = 0,
-      const char* keysym = 0) {
-    SetEventInformation(x + (this->Size[0]/2), (this->Size[1]/2) - y,ctrl,shift,keycode,repeatcount,keysym);
-  }
-
-  // Set information, so that (0,0) represents no rotation
-/*
-  inline void SetEventInformationFromOrigin(
-      int x, 
-      int y, 
-      int ctrl = 0, 
-      int shift = 0, 
-      char keycode = 0, 
-      int repeatcount = 0,
-      const char* keysym = 0) {
-    SetEventInformation(x + (this->Size[0]/2), (this->Size[1]/2) - y,ctrl,shift,keycode,repeatcount,keysym);
-  }
-*/
-
-  int PrevX;
-  int PrevY;
 
   long Handle;
   bool Created;


### PR DESCRIPTION
While panning, the shift key need to be held. This caused the KeyDown event to be continuously fired. This caused lag and undesired behaviour.